### PR TITLE
⚡ Optimize `segment_web_page_views__sessionized` for Babylist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# babylist/dbt_segment v0.1.0
+
+This release restarts versioning at v0.8.1 of the upstream repo, which is what we're using as of April 2024.
+
 # segment v0.8.1
 ## Fixes
 - Fix duplication of sources in incremental materializations ([#80](https://github.com/dbt-labs/segment/issues/80), [#81](https://github.com/dbt-labs/segment/pull/81))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,27 +5,33 @@
 - Remove expensive deduplication of source page views, which is already handled upstream in our dbt models
 - Add uniquifying element to page view sessionization to account for subsetting of source page view model
 
-
 # babylist/dbt_segment v0.1.0
 
 This release restarts versioning at v0.8.1 of the upstream repo, which is what we're using as of April 2024.
 
 # segment v0.8.1
+
 ## Fixes
+
 - Fix duplication of sources in incremental materializations ([#80](https://github.com/dbt-labs/segment/issues/80), [#81](https://github.com/dbt-labs/segment/pull/81))
 
-Contributors: 
+Contributors:
+
 - [rjh336](https://github.com/rjh336) (#81)
 
 # segment v0.8.0
+
 ## New Features
+
 - Postgres Support ([#69](https://github.com/dbt-labs/segment/issues/69), [#70](https://github.com/dbt-labs/segment/pull/70))
 
 ## Improvements
+
 - Significantly improved BigQuery performance ([#72](https://github.com/dbt-labs/segment/issues/72), [#73](https://github.com/dbt-labs/segment/pull/73))
 - Deduplication of source page views ([#76](https://github.com/dbt-labs/segment/pull/76))
 
-Contributors: 
+Contributors:
+
 - [shippy](https://github.com/shippy) (#70)
 - [rjh336](https://github.com/rjh336) (#73)
 - [MarkMacArdle](https://github.com/MarkMacArdle) (#76)
@@ -35,6 +41,7 @@ Contributors:
 This release supports any version (minor and patch) of v1, which means far less need for compatibility releases in the future.
 
 ## Under the hood
+
 - Change `require-dbt-version` to `[">=1.0.0", "<2.0.0"]`
 - Bump dbt-utils dependency
 - Replace `source-paths` and `data-paths` with `model-paths` and `seed-paths` respectively
@@ -42,4 +49,5 @@ This release supports any version (minor and patch) of v1, which means far less 
 - Replace `dbt_modules` with `dbt_packages` in `clean-targets`
 
 # segment v0.6.1
+
 🚨 This is a compatibility release in preparation for `dbt-core` v1.0.0 (🎉). Projects using this version with `dbt-core` v1.0.x can expect to see a deprecation warning. This will be resolved in the next minor release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# babylist/dbt_segment v0.2.0
+
+## Improvements
+
+- Remove expensive deduplication of source page views, which is already handled upstream in our dbt models
+- Add uniquifying element to page view sessionization to account for subsetting of source page view model
+
+
 # babylist/dbt_segment v0.1.0
 
 This release restarts versioning at v0.8.1 of the upstream repo, which is what we're using as of April 2024.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-# dbt-segment
+# dbt_segment
 
 This [dbt package](https://docs.getdbt.com/docs/package-management):
 
 * Performs "user stitching" to tie all events associated with a cookie to the same user_id
 * Transforms pageviews into sessions ("sessionization")
+
+This has been forked from the original upstream repo by dbt Labs in order to apply optimizations for Babylist's dbt project.
 
 ## Installation instructions
 

--- a/README.md
+++ b/README.md
@@ -13,41 +13,41 @@ New to dbt packages? Read more about them [here](https://docs.getdbt.com/docs/bu
 2. Run `dbt deps`
 3. Include the following in your `dbt_project.yml` directly within your `vars:` block (making sure to handle indenting appropriately). **Update the value to point to your segment page views table**.
 
-```YAML
-# dbt_project.yml
-config-version: 2
-...
+    ```YAML
+    # dbt_project.yml
+    config-version: 2
+    ...
 
-vars:
-  segment:
-    segment_page_views_table: "{{ source('segment', 'pages') }}"
+    vars:
+      segment:
+        segment_page_views_table: "{{ source('segment', 'pages') }}"
 
-```
+    ```
 
-This package assumes that your data is in a structure similar to the test
-file included in [example_segment_pages](integration_tests/seeds/example_segment_pages.csv).
-You may have to do some pre-processing in an upstream model to get it into this shape.
-Similarly, if you need to union multiple sources, de-duplicate records, or filter
-out bad records, do this in an upstream model.
+    This package assumes that your data is in a structure similar to the test
+    file included in [example_segment_pages](integration_tests/seeds/example_segment_pages.csv).
+    You may have to do some pre-processing in an upstream model to get it into this shape.
+    Similarly, if you need to union multiple sources, de-duplicate records, or filter
+    out bad records, do this in an upstream model.
 
 4. Optionally configure extra parameters by adding them to your own `dbt_project.yml` file – see [dbt_project.yml](dbt_project.yml)
 for more details:
 
-```YAML
-# dbt_project.yml
-config-version: 2
+    ```YAML
+    # dbt_project.yml
+    config-version: 2
 
-...
+    ...
 
-vars:
-  segment:
-    segment_page_views_table: "{{ source('segment', 'pages') }}"
-    segment_sessionization_trailing_window: 3
-    segment_inactivity_cutoff: 30 * 60
-    segment_pass_through_columns: []
-    segment_bigquery_partition_granularity: 'day' # BigQuery only: partition granularity for `partition_by` config
+    vars:
+      segment:
+        segment_page_views_table: "{{ source('segment', 'pages') }}"
+        segment_sessionization_trailing_window: 3
+        segment_inactivity_cutoff: 30 * 60
+        segment_pass_through_columns: []
+        segment_bigquery_partition_granularity: 'day' # BigQuery only: partition granularity for `partition_by` config
 
-```
+    ```
 
 5. Execute `dbt seed` -- this project includes a CSV that must be seeded for it
 the package to run successfully.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # dbt-segment
+
 This [dbt package](https://docs.getdbt.com/docs/package-management):
+
 * Performs "user stitching" to tie all events associated with a cookie to the same user_id
 * Transforms pageviews into sessions ("sessionization")
 
-
 ## Installation instructions
+
 New to dbt packages? Read more about them [here](https://docs.getdbt.com/docs/building-a-dbt-project/package-management/).
+
 1. Include this package in your `packages.yml` — check [here](https://hub.getdbt.com/dbt-labs/segment/latest/) for the latest version number.
 2. Run `dbt deps`
 3. Include the following in your `dbt_project.yml` directly within your `vars:` block (making sure to handle indenting appropriately). **Update the value to point to your segment page views table**.
@@ -20,6 +23,7 @@ vars:
     segment_page_views_table: "{{ source('segment', 'pages') }}"
 
 ```
+
 This package assumes that your data is in a structure similar to the test
 file included in [example_segment_pages](integration_tests/seeds/example_segment_pages.csv).
 You may have to do some pre-processing in an upstream model to get it into this shape.
@@ -44,12 +48,15 @@ vars:
     segment_bigquery_partition_granularity: 'day' # BigQuery only: partition granularity for `partition_by` config
 
 ```
+
 5. Execute `dbt seed` -- this project includes a CSV that must be seeded for it
 the package to run successfully.
 6. Execute `dbt run` – the Segment models will get built as part of your run!
 
 ## Database support
+
 This package has been tested on Redshift, Snowflake, BigQuery, and Postgres.
 
 ### Contributing
+
 Additional contributions to this repo are very welcome! Check out [this post](https://discourse.getdbt.com/t/contributing-to-a-dbt-package/657) on the best workflow for contributing to a package. All PRs should only include functionality that is contained within all Segment deployments; no implementation-specific details should be included.

--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ for more details:
 
     ```
 
-5. Execute `dbt seed` -- this project includes a CSV that must be seeded for it
-the package to run successfully.
+5. Execute `dbt seed` -- this project includes a CSV that must be seeded for the package to run successfully.
 6. Execute `dbt run` – the Segment models will get built as part of your run!
 
 ## Database support

--- a/models/base/segment_web_page_views.sql
+++ b/models/base/segment_web_page_views.sql
@@ -4,24 +4,6 @@ with source as (
 
 ),
 
-row_numbering as (
-
-    select
-        *,
-        row_number() over (partition by id order by received_at asc) as row_num
-    from source
-
-),
-
-deduped as (
-
-    select
-        *
-    from row_numbering
-    where row_num = 1
-
-),
-
 renamed as (
 
     select
@@ -68,7 +50,7 @@ renamed as (
 
         {% endif %}
 
-    from deduped
+    from source
 
 ),
 

--- a/models/base/segment_web_page_views.sql
+++ b/models/base/segment_web_page_views.sql
@@ -15,6 +15,7 @@ renamed as (
         received_at as received_at_tstamp,
         sent_at as sent_at_tstamp,
         timestamp as tstamp,
+        event_date,
 
         url as page_url,
         {{ dbt_utils.get_url_host('url') }} as page_url_host,

--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -118,6 +118,26 @@ session_numbers as (
 
 ),
 
+session_starts as (
+
+    --This CTE calculates the first event timestamp within any session number.
+    --Because our version of the Segment package only evaluates a sliding window
+    --of events in this model, we need to guarantee uniqueness when we calculate
+    --session_id. `session_number` is no longer globally unique so we uniquify
+    --it with the addition of the start timestamp.
+
+    select
+
+        *,
+
+        min(tstamp) over (
+            partition by anonymous_id, session_number
+            ) as session_start_tstamp
+
+    from session_numbers
+
+)
+
 session_ids as (
 
     --This CTE assigns a globally unique session id based on the combination of
@@ -127,9 +147,9 @@ session_ids as (
 
         {{dbt_utils.star(ref('segment_web_page_views'))}},
         page_view_number,
-        {{dbt_utils.surrogate_key(['anonymous_id', 'event_date', 'session_number'])}} as session_id
+        {{dbt_utils.surrogate_key(['anonymous_id', 'session_start_testamp', 'session_number'])}} as session_id
 
-    from session_numbers
+    from session_starts
 
 )
 

--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -127,7 +127,7 @@ session_ids as (
 
         {{dbt_utils.star(ref('segment_web_page_views'))}},
         page_view_number,
-        {{dbt_utils.surrogate_key(['anonymous_id', 'session_number'])}} as session_id
+        {{dbt_utils.surrogate_key(['anonymous_id', 'event_date', 'session_number'])}} as session_id
 
     from session_numbers
 

--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -147,7 +147,7 @@ session_ids as (
 
         {{dbt_utils.star(ref('segment_web_page_views'))}},
         page_view_number,
-        {{dbt_utils.surrogate_key(['anonymous_id', 'session_start_testamp', 'session_number'])}} as session_id
+        {{dbt_utils.surrogate_key(['anonymous_id', 'session_start_tstamp', 'session_number'])}} as session_id
 
     from session_starts
 

--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -136,7 +136,7 @@ session_starts as (
 
     from session_numbers
 
-)
+),
 
 session_ids as (
 


### PR DESCRIPTION
## Description & motivation

`segment_web_page_views__sessionized` is the longest-running model for us. Looking at the query profile, the most expensive operations are table scans and the deduping window functions.

1. To address table scans, we will have a corresponding PR in our dbt repo to use a sliding window of events as the input (`segment_web_page_views`). This will result in `session_number` collisions unless we add a uniquifying element; in this case, `session_start_tstamp` is used.

2. The deduping window functions can be removed because we already handle deduping upstream.

This PR also includes documentation updates.

## Test process

- Produced a smaller subset of `segment_web_page_views` by limiting to events since 4/1/2023
- Built the package incrementally: `dbt build -s segment`
- Compared aggregate number of rows and distinct sessions compared to a test run on the same dataset with unchanged package code

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)

## Post-merge checklist

- [ ] Tag new commit and push tag