### PR TITLE
🐛 DATA-3169: Fix unintended changes to `session_id`

### DIFF
--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -145,7 +145,7 @@ session_ids as (
 
     select
 
-        {{dbt_utils.star(ref('segment_web_page_views'), relation_alias='session_starts')}},
+        {{dbt_utils.star(from=ref('segment_web_page_views'), relation_alias='session_starts')}},
         session_starts.page_view_number,
         {% if is_incremental() %}sessionized.session_id{% else %}null::string{% endif %} as existing_session_id,
         {{dbt_utils.surrogate_key(['session_starts.anonymous_id', 'session_starts.session_start_tstamp', 'session_starts.session_number'])}} as session_id

--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -145,10 +145,10 @@ session_ids as (
 
     select
 
-        {{dbt_utils.star(ref('segment_web_page_views'))}},
-        page_view_number,
+        {{dbt_utils.star(ref('segment_web_page_views'), relation_alias='session_starts')}},
+        session_starts.page_view_number,
         {% if is_incremental() %}sessionized.session_id{% else %}null::string{% endif %} as existing_session_id,
-        {{dbt_utils.surrogate_key(['anonymous_id', 'session_start_tstamp', 'session_number'])}} as session_id
+        {{dbt_utils.surrogate_key(['session_starts.anonymous_id', 'session_starts.session_start_tstamp', 'session_starts.session_number'])}} as session_id
 
     from session_starts
     {% if is_incremental() %}

--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -140,13 +140,16 @@ session_starts as (
 
 session_ids as (
 
-    --This CTE assigns a globally unique session id based on the combination of
-    --`anonymous_id` and `session_number`.
+    --This CTE assigns a unique session id based on the combination of
+    --`anonymous_id`, `session_start_tstamp`, and `session_number`.
+    --including `session_start_tstamp` helps us uniquify since we no longer
+    --include the full lifetime of events in `segment_web_page_views`.
 
     select
 
         {{dbt_utils.star(from=ref('segment_web_page_views'), relation_alias='session_starts')}},
         session_starts.page_view_number,
+        --if an event has previously been sessionized, keep the existing session ID
         {% if is_incremental() %}sessionized.session_id{% else %}null::string{% endif %} as existing_session_id,
         {{dbt_utils.surrogate_key(['session_starts.anonymous_id', 'session_starts.session_start_tstamp', 'session_starts.session_number'])}} as session_id
 
@@ -162,6 +165,8 @@ consolidated_session as (
 
     select
         * exclude (existing_session_id, session_id),
+        --this line handles new events that are part of an existing session - instead of assigning a brand new
+        --session ID, see if there's an existing session ID from other events in the same session, and use that
         min_by(coalesce(existing_session_id, session_id), tstamp) over (partition by session_id) as session_id
     from session_ids
 


### PR DESCRIPTION
## Description & motivation

After our changes in #1, we started noticing that events would frequently get new `session_id`s.

This is because `session_id` is being derived from `session_number`, and `session_number` for any given session will actually change over time. i.e. session 3 today could become session 1 tomorrow as an entire day's worth of events is excluded from the incremental load.

In order to get more consistent session IDs, we need to use existing IDs for events (`page_view_id`s) that have already been assigned a session.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)

## Post-merge checklist

- [ ] Tag new commit and push tag