### PR TITLE
Fix coalesce positioning in `consolidated_session` CTE

### DIFF
--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -167,7 +167,10 @@ consolidated_session as (
         * exclude (existing_session_id, session_id),
         --this line handles new events that are part of an existing session - instead of assigning a brand new
         --session ID, see if there's an existing session ID from other events in the same session, and use that
-        min_by(coalesce(existing_session_id, session_id), tstamp) over (partition by session_id) as session_id
+        coalesce(
+            min_by(existing_session_id, tstamp) over (partition by session_id),
+            session_id
+        ) as session_id
     from session_ids
 
 )

--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -168,8 +168,8 @@ consolidated_session as (
         --this line handles new events that are part of an existing session - instead of assigning a brand new
         --session ID, see if there's an existing session ID from other events in the same session, and use that
         coalesce(
-            min_by(existing_session_id, tstamp) over (partition by session_id),
-            session_id
+            min_by(existing_session_id, tstamp) over (partition by session_id), --existing ID across the session
+            session_id --fall back to new session_id
         ) as session_id
     from session_ids
 


### PR DESCRIPTION
## Description & motivation

In #2, new logic was added to use an existing session ID when possible, but the positioning of the `coalesce` is incorrect:

```sql
min_by(coalesce(existing_session_id, session_id), tstamp) over (partition by session_id)
```

Placing the `coalesce` _inside_ the `min_by` means that for the partition, rows without an `existing_session_id` still have a value (the new `session_id`), and that value is applied across the entire partition.

The effect is somewhat the opposite of the intention: every time a new `session_id` is generated, it's applied to all events within that session. The intended effect is that when a new `session_id` is generated, it's only used if all events within that session have not already been sessionized.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
