### PR TITLE
Changed `min_by` to `min`

### DIFF
--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -169,7 +169,7 @@ consolidated_session as (
         --this line handles new events that are part of an existing session - instead of assigning a brand new
         --session ID, see if there's an existing session ID from other events in the same session, and use that
         coalesce(
-            min_by(existing_session_id, tstamp) over (partition by anonymous_id, session_start_tstamp), --existing ID across the session
+            min(existing_session_id) over (partition by anonymous_id, session_start_tstamp), --existing ID across the session
             session_id --fall back to new session_id
         ) as session_id
     from session_ids


### PR DESCRIPTION
We have noticed some edge cases where the `min_by` logic incorrectly pulls all `null` for a given session, causing the events to move to a new session ID.

We are partitioning at a grain that should allow us to safely use `min` which will avoid this issue.