### PR TITLE
⚡ Change intermediate models to table materialization

### DIFF
--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -1,5 +1,5 @@
 {{ config(
-    materialized = 'incremental',
+    materialized = 'table',
     unique_key = 'page_view_id',
     sort = 'tstamp',
     partition_by = {'field': 'tstamp', 'data_type': 'timestamp', 'granularity': var('segment_bigquery_partition_granularity')},

--- a/models/sessionization/segment_web_sessions__initial.sql
+++ b/models/sessionization/segment_web_sessions__initial.sql
@@ -1,5 +1,5 @@
 {{ config(
-    materialized = 'incremental',
+    materialized = 'table',
     unique_key = 'session_id',
     sort = 'session_start_tstamp',
     partition_by = {'field': 'session_start_tstamp', 'data_type': 'timestamp', 'granularity': var('segment_bigquery_partition_granularity')},

--- a/models/sessionization/segment_web_sessions__stitched.sql
+++ b/models/sessionization/segment_web_sessions__stitched.sql
@@ -1,5 +1,5 @@
 {{ config(
-    materialized = 'incremental',
+    materialized = 'table',
     unique_key = 'session_id',
     sort = 'session_start_tstamp',
     partition_by = {'field': 'session_start_tstamp', 'data_type': 'timestamp', 'granularity': var('segment_bigquery_partition_granularity')},


### PR DESCRIPTION
## Description & motivation

We don't actually need the modified models to be incremental, as we don't query the actual data*. The upstream `segment_web_page_views` model is now a fixed 7-day window of data, so making these models tables will limit the amount of data in them, which we observed has reduced the time it takes to build the models in this package, and therefore reduce our overall dbt job duration.

*We do reference `segment_web_page_views__sessionized` in `dbt_models` in a couple incremental models, but we don't intend to do a full refresh on those in the future.

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
