### PR TITLE
Added `full_refresh` config on `segment_web_sessions`

### DIFF
--- a/models/sessionization/segment_web_sessions.sql
+++ b/models/sessionization/segment_web_sessions.sql
@@ -4,7 +4,8 @@
     sort = 'session_start_tstamp',
     partition_by = {'field': 'session_start_tstamp', 'data_type': 'timestamp', 'granularity': var('segment_bigquery_partition_granularity')},
     dist = 'session_id',
-    cluster_by = 'session_id'
+    cluster_by = 'session_id',
+    full_refresh = false
     )}}
 
 {#


### PR DESCRIPTION
## Description & motivation
As part of incident 116 - we don't want our `segment_web_sessions` table to be fully refreshed.  We need this model to retain its full history
