### PR TITLE
Revert "⚡ Change intermediate models to table materialization (#10)"

### DIFF
--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -1,5 +1,5 @@
 {{ config(
-    materialized = 'table',
+    materialized = 'incremental',
     unique_key = 'page_view_id',
     sort = 'tstamp',
     partition_by = {'field': 'tstamp', 'data_type': 'timestamp', 'granularity': var('segment_bigquery_partition_granularity')},

--- a/models/sessionization/segment_web_sessions__initial.sql
+++ b/models/sessionization/segment_web_sessions__initial.sql
@@ -1,5 +1,5 @@
 {{ config(
-    materialized = 'table',
+    materialized = 'incremental',
     unique_key = 'session_id',
     sort = 'session_start_tstamp',
     partition_by = {'field': 'session_start_tstamp', 'data_type': 'timestamp', 'granularity': var('segment_bigquery_partition_granularity')},

--- a/models/sessionization/segment_web_sessions__stitched.sql
+++ b/models/sessionization/segment_web_sessions__stitched.sql
@@ -1,5 +1,5 @@
 {{ config(
-    materialized = 'table',
+    materialized = 'incremental',
     unique_key = 'session_id',
     sort = 'session_start_tstamp',
     partition_by = {'field': 'session_start_tstamp', 'data_type': 'timestamp', 'granularity': var('segment_bigquery_partition_granularity')},


### PR DESCRIPTION
This reverts commit b4bb955fa4f2278fb116d561cdcc5f52380f8f92.

## Description & motivation

We may be having unintended side effects by making these full-table models. The logic that checks for existing sessions is no longer firing.
