### PR TITLE
Set no full-refresh config for Incremental tables

### DIFF
--- a/models/sessionization/segment_web_page_views__sessionized.sql
+++ b/models/sessionization/segment_web_page_views__sessionized.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized = 'incremental',
+    full_refresh=false,
     unique_key = 'page_view_id',
     sort = 'tstamp',
     partition_by = {'field': 'tstamp', 'data_type': 'timestamp', 'granularity': var('segment_bigquery_partition_granularity')},

--- a/models/sessionization/segment_web_sessions.sql
+++ b/models/sessionization/segment_web_sessions.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized = 'incremental',
+    full_refresh=false,
     unique_key = 'session_id',
     sort = 'session_start_tstamp',
     partition_by = {'field': 'session_start_tstamp', 'data_type': 'timestamp', 'granularity': var('segment_bigquery_partition_granularity')},

--- a/models/sessionization/segment_web_sessions__initial.sql
+++ b/models/sessionization/segment_web_sessions__initial.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized = 'incremental',
+    full_refresh=false,
     unique_key = 'session_id',
     sort = 'session_start_tstamp',
     partition_by = {'field': 'session_start_tstamp', 'data_type': 'timestamp', 'granularity': var('segment_bigquery_partition_granularity')},

--- a/models/sessionization/segment_web_sessions__stitched.sql
+++ b/models/sessionization/segment_web_sessions__stitched.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized = 'incremental',
+    full_refresh=false,
     unique_key = 'session_id',
     sort = 'session_start_tstamp',
     partition_by = {'field': 'session_start_tstamp', 'data_type': 'timestamp', 'granularity': var('segment_bigquery_partition_granularity')},


### PR DESCRIPTION
## Description & motivation
Related to [INC-219](https://babylist.slack.com/archives/C0918472FPT) (fixing missing health & core event sessionization)

Now that these tables have been restored to incremental materialization, and the refresh is complete, we need to add the refresh protections



## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
